### PR TITLE
BS - removes incorrect package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "team00-s23-7pm-4",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
In this PR, I removed the incorrect package-lock.json that I accidentally created in the wrong folder.